### PR TITLE
Render overlay properly on older browsers

### DIFF
--- a/userscript.user.js
+++ b/userscript.user.js
@@ -15,7 +15,7 @@ if (window.top !== window.self) {
         (function () {
             const i = document.createElement("img");
             i.src = "https://github.com/r-PlaceTux/Overlay/raw/main/tuxoverlay.png";
-            i.style = "position: absolute;left: 0;top: 0;image-rendering: pixelated;width: 1000px;height: 1000px;";
+            i.style = "position: absolute;left: 0;top: 0;image-rendering: crisp-edges;width: 1000px;height: 1000px;";
             console.log(i);
             return i;
         })())


### PR DESCRIPTION
The MDN Web Docs define the `pixelated` value for `image-rendering` as experimental. Chrome and Edge have supported that value for a long time but on Firefox, only versions 93 and above support it.
The `crisp-edges` is an alternative to `pixelated` that has been supported for a very long time across all browsers and it also makes the image be rendered with nearest-neighbour